### PR TITLE
Fix to allow Deployment to Azure

### DIFF
--- a/AzureRpdeProxy/AzureRpdeProxy.csproj
+++ b/AzureRpdeProxy/AzureRpdeProxy.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -8,13 +8,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="3.3.0" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.1" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.24" />
+    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.1.3" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Http" Version="3.0.12" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.ServiceBus" Version="4.3.0" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.13" />
     <PackageReference Include="NPoco" Version="3.9.4" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.6.0" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/AzureRpdeProxyDeployment/azuredeploy.json
+++ b/AzureRpdeProxyDeployment/azuredeploy.json
@@ -81,6 +81,9 @@
   },
   "resources": [
     {
+      "tags": {
+        "displayName": "SqlServer"
+      },
       "apiVersion": "2014-04-01",
       "location": "[resourceGroup().location]",
       "name": "[variables('sqlserverName')]",
@@ -91,15 +94,15 @@
       },
       "resources": [
         {
+          "tags": {
+            "displayName": "Database"
+          },
           "name": "[variables('databaseName')]",
           "type": "databases",
           "dependsOn": [
             "[resourceId('Microsoft.Sql/servers', variables('sqlserverName'))]"
           ],
           "location": "[resourceGroup().location]",
-          "tags": {
-            "displayName": "Database"
-          },
           "apiVersion": "2015-01-01",
           "properties": {
             "edition": "Standard",
@@ -109,6 +112,9 @@
           },
           "resources": [
             {
+              "tags": {
+                "displayName": "BackupPolicies"
+              },
               "name": "Default",
               "type": "backupShortTermRetentionPolicies",
               "dependsOn": [
@@ -148,12 +154,12 @@
           }
         }
       ],
-      "tags": {
-        "displayName": "SqlServer"
-      },
       "type": "Microsoft.Sql/servers"
     },
     {
+      "tags": {
+        "displayName": "StorageAccount"
+      },
       "type": "Microsoft.Storage/storageAccounts",
       "name": "[variables('storageAccountName')]",
       "apiVersion": "2015-06-15",
@@ -163,6 +169,9 @@
       }
     },
     {
+      "tags": {
+        "displayName": "ServiceBus"
+      },
       "apiVersion": "2017-04-01",
       "name": "[variables('serviceBusNamespaceName')]",
       "type": "Microsoft.ServiceBus/namespaces",
@@ -173,6 +182,9 @@
       "properties": {},
       "resources": [
         {
+          "tags": {
+            "displayName": "PurgeQueue"
+          },
           "apiVersion": "2017-04-01",
           "name": "[variables('serviceBusQueueNamePurge')]",
           "type": "Queues",
@@ -192,6 +204,9 @@
           }
         },
         {
+          "tags": {
+            "displayName": "FeedstateQueue"
+          },
           "apiVersion": "2017-04-01",
           "name": "[variables('serviceBusQueueNameFeedstate')]",
           "type": "Queues",
@@ -211,6 +226,9 @@
           }
         },
         {
+          "tags": {
+            "displayName": "RegistrationQueue"
+          },
           "apiVersion": "2017-04-01",
           "name": "[variables('serviceBusQueueNameRegistration')]",
           "type": "Queues",
@@ -232,12 +250,14 @@
       ]
     },
     {
+      "tags": {
+        "displayName": "Insights"
+      },
       "type": "microsoft.insights/components",
       "kind": "other",
       "name": "[variables('appInsightsServiceName')]",
       "apiVersion": "2014-04-01",
-      "location": "West Europe",
-      "tags": {},
+      "location": "UK South",
       "scale": null,
       "properties": {
         "ApplicationId": "[variables('appInsightsServiceName')]"
@@ -245,6 +265,9 @@
       "dependsOn": []
     },
     {
+      "tags": {
+        "displayName": "ServerFarm"
+      },
       "type": "Microsoft.Web/serverfarms",
       "apiVersion": "2015-04-01",
       "name": "[variables('hostingPlanName')]",
@@ -256,6 +279,9 @@
       }
     },
     {
+      "tags": {
+        "displayName": "Sites"
+      },
       "apiVersion": "2015-08-01",
       "type": "Microsoft.Web/sites",
       "name": "[variables('functionAppName')]",
@@ -343,6 +369,9 @@
       ],
       "resources": [
         {
+          "tags": {
+            "displayName": "SourceControls"
+          },
           "apiVersion": "2015-08-01",
           "name": "web",
           "type": "sourcecontrols",


### PR DESCRIPTION
It seems that Azure does not now allow new deployments using deprecated versions of .NETCore. Cryptically, the deployment reports a 'Conflict' when attempting to deploy the SourceControls but gives no clue as to the conflict. Digging deep into Azure and finding some logs gave the indication it was to do with the netcore version. 

Therefore this repo needs to be updated to 3.1 (LTS) from 2.1 to allow a successful deployment to run.

Changes :
Upped function app netcore to 3.1 from 2.1
Updated all Microsoft nuget packages to latest
Tweak deployment script to make sure all resources have decent names when viewed in JSON Outline
Updated Insights location in deployment script to be UK South